### PR TITLE
fix: typo in node type robot state publisher

### DIFF
--- a/p3at_description/launch/p3at.launch
+++ b/p3at_description/launch/p3at.launch
@@ -16,6 +16,6 @@
 
 <node pkg="gazebo_ros" type="spawn_model" name="spawn_model" args="-urdf -param /robot_description -model pioneer3at"/>
 
-<node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher"/>
+<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher"/>
 
 </launch>

--- a/p3at_description/launch/spawn_p3at.launch
+++ b/p3at_description/launch/spawn_p3at.launch
@@ -13,7 +13,7 @@
   
     <param name="tf_prefix" type="string" value="$(arg robot_name)" />
   
-    <node pkg="robot_state_publisher" type="state_publisher" name="robot_state_publisher">
+    <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
       <!--<remap from="robot_description" to="robot_description_$(arg robot_name)" />-->
     </node>  
   </group>


### PR DESCRIPTION
Fixes a minor bug of calling robot state publisher node

<img width="723" alt="image" src="https://github.com/user-attachments/assets/8794718f-2576-474a-bfbc-04afb5544481">
